### PR TITLE
Use Data.Generic.Rep

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,6 +17,6 @@
     "package.json"
   ],
   "dependencies": {
-    "purescript-generics": "^4.0.0"
+    "purescript-generics-rep": "^5.3.0"
   }
 }

--- a/src/Data/HTTP/Method.purs
+++ b/src/Data/HTTP/Method.purs
@@ -9,7 +9,7 @@ module Data.HTTP.Method
 import Prelude
 
 import Data.Either (Either(..), either)
-import Data.Generic (class Generic)
+import Data.Generic.Rep (class Generic)
 import Data.String as Str
 
 data Method
@@ -37,7 +37,7 @@ data Method
 
 derive instance eqMethod :: Eq Method
 derive instance ordMethod :: Ord Method
-derive instance genericMethod :: Generic Method
+derive instance genericMethod :: Generic Method _
 
 instance showMethod :: Show Method where
   show OPTIONS = "OPTIONS"
@@ -64,7 +64,7 @@ unCustomMethod (CustomMethod m) = m
 
 derive instance eqCustomMethod :: Eq CustomMethod
 derive instance ordCustomMethod :: Ord CustomMethod
-derive instance genericCustomMethod :: Generic CustomMethod
+derive instance genericCustomMethod :: Generic CustomMethod _
 
 instance showCustomMethod :: Show CustomMethod where
   show (CustomMethod m) = "(CustomMethod " <> show m <> ")"


### PR DESCRIPTION
Maybe `CustomMethod` shouldn't have a `Generic.Rep` instance at all, since its constructor is not exported.